### PR TITLE
[POST] /categories/search 카테고리 조회 API 추가

### DIFF
--- a/problem1/build.gradle
+++ b/problem1/build.gradle
@@ -28,6 +28,26 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    // Spring boot 3.x이상에서 QueryDsl 패키지를 정의하는 방법
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+}
+
+// === QueryDsl 빌드 옵션 (선택) ===
+def querydslDir = "$buildDir/generated/querydsl"
+
+sourceSets {
+    main.java.srcDirs += [ querydslDir ]
+}
+
+tasks.withType(JavaCompile) {
+    options.generatedSourceOutputDirectory = file(querydslDir)
+}
+
+clean.doLast {
+    file(querydslDir).deleteDir()
 }
 
 tasks.named('test') {

--- a/problem1/src/main/java/com/board/toy/common/ApiExceptionHandler.java
+++ b/problem1/src/main/java/com/board/toy/common/ApiExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.board.toy.common;
+
+import com.board.toy.common.exceptions.NotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class ApiExceptionHandler {
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity handleNotFoundException(NotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+    }
+}

--- a/problem1/src/main/java/com/board/toy/common/config/QuerydslConfiguration.java
+++ b/problem1/src/main/java/com/board/toy/common/config/QuerydslConfiguration.java
@@ -1,0 +1,19 @@
+package com.board.toy.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfiguration {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/problem1/src/main/java/com/board/toy/common/exceptions/NotFoundException.java
+++ b/problem1/src/main/java/com/board/toy/common/exceptions/NotFoundException.java
@@ -1,0 +1,4 @@
+package com.board.toy.common.exceptions;
+
+public class NotFoundException extends RuntimeException{
+}

--- a/problem1/src/main/java/com/board/toy/domain/board/repository/BoardRepository.java
+++ b/problem1/src/main/java/com/board/toy/domain/board/repository/BoardRepository.java
@@ -1,0 +1,7 @@
+package com.board.toy.domain.board.repository;
+
+import com.board.toy.domain.board.Board;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardRepository extends JpaRepository<Board, Long> {
+}

--- a/problem1/src/main/java/com/board/toy/domain/category/Category.java
+++ b/problem1/src/main/java/com/board/toy/domain/category/Category.java
@@ -1,8 +1,10 @@
 package com.board.toy.domain.category;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 
 @Entity
+@Getter
 public class Category {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/problem1/src/main/java/com/board/toy/domain/category/CategoryController.java
+++ b/problem1/src/main/java/com/board/toy/domain/category/CategoryController.java
@@ -1,0 +1,20 @@
+package com.board.toy.domain.category;
+
+import com.board.toy.domain.category.dto.CategorySearchRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/categories")
+public class CategoryController {
+    private final CategoryService categoryService;
+
+    @PostMapping("/search")
+    public ResponseEntity search(@RequestBody CategorySearchRequestDto dto){
+        return ResponseEntity.ok(categoryService.search(dto));
+    }
+
+
+}

--- a/problem1/src/main/java/com/board/toy/domain/category/CategoryService.java
+++ b/problem1/src/main/java/com/board/toy/domain/category/CategoryService.java
@@ -1,0 +1,36 @@
+package com.board.toy.domain.category;
+
+import com.board.toy.common.exceptions.NotFoundException;
+import com.board.toy.domain.category.dto.CategorySearchDto;
+import com.board.toy.domain.category.dto.CategorySearchRequestDto;
+import com.board.toy.domain.category.dto.CategorySearchResponseDto;
+import com.board.toy.domain.category.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+    private final CategoryRepository categoryRepository;
+    private final int indexThatHasNoBoard = 0;
+    public CategorySearchResponseDto search(CategorySearchRequestDto dto) {
+        Long categoryId = dto.getCategoryId();
+        Optional<Category> target;
+        if (categoryId == null) {
+            //todo 1 현재시점에선 키워드로 검색했을때, 하나만 받지만.. %키워드% 검색으로 결과가 여러개 나올 수도 있으므로  해당 부분 검토 필요
+            //todo 2 지금 이대로 나가면 n+1 문제 발생하므로 dto로 가져오거나 fetch join으로 교체
+            target = categoryRepository.findOneByNameContains(dto.getNameKeyword());
+            }
+        else{
+            target = categoryRepository.findById(categoryId);
+        }
+        target.orElseThrow(NotFoundException::new);
+        categoryId = target.get().getId();
+        List<CategorySearchDto> result = categoryRepository.findSearchCategories(categoryId);
+        result.remove(indexThatHasNoBoard);//todo 여러개의 카테고리를 다루게 될때, stream으로 그룹화 해서 결과값 다뤄야함
+        return new CategorySearchResponseDto(target.get(),result);
+    }
+}

--- a/problem1/src/main/java/com/board/toy/domain/category/dto/CategorySearchDto.java
+++ b/problem1/src/main/java/com/board/toy/domain/category/dto/CategorySearchDto.java
@@ -1,0 +1,48 @@
+package com.board.toy.domain.category.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+
+@Getter
+public class CategorySearchDto {
+
+    @JsonIgnore
+    private Long categoryId;
+
+    @JsonIgnore
+    private String categoryName;
+
+    @JsonIgnore
+    private Boolean categoryIsDel;
+
+    @JsonIgnore
+    private Long categoryParentId;
+
+    @JsonIgnore
+    private Long mappingId;
+
+    private Long boardId;
+
+    private String boardName;
+
+    private Boolean boardIsDel;
+
+    private Boolean boardIsAnonymous;
+
+    @QueryProjection
+
+    public CategorySearchDto(Long categoryId, String categoryName, Boolean categoryIsDel, Long categoryParentId,
+                             Long mappingId,
+                             Long boardId, String boardName, Boolean boardIsDel, Boolean boardIsAnonymous) {
+        this.categoryId = categoryId;
+        this.categoryName = categoryName;
+        this.categoryIsDel = categoryIsDel;
+        this.categoryParentId = categoryParentId;
+        this.mappingId = mappingId;
+        this.boardId = boardId;
+        this.boardName = boardName;
+        this.boardIsDel = boardIsDel;
+        this.boardIsAnonymous = boardIsAnonymous;
+    }
+}

--- a/problem1/src/main/java/com/board/toy/domain/category/dto/CategorySearchRequestDto.java
+++ b/problem1/src/main/java/com/board/toy/domain/category/dto/CategorySearchRequestDto.java
@@ -1,0 +1,10 @@
+package com.board.toy.domain.category.dto;
+
+import lombok.Getter;
+
+@Getter
+public class CategorySearchRequestDto {
+    private Long categoryId;
+    private String nameKeyword;
+    //todo validation: 적어도 하나의 멤버 변수가 null이 아니도록 검증
+}

--- a/problem1/src/main/java/com/board/toy/domain/category/dto/CategorySearchResponseDto.java
+++ b/problem1/src/main/java/com/board/toy/domain/category/dto/CategorySearchResponseDto.java
@@ -1,0 +1,21 @@
+package com.board.toy.domain.category.dto;
+
+import com.board.toy.domain.category.Category;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class CategorySearchResponseDto {
+    private SimpleCategoryDto parentIdx;
+    private SimpleCategoryDto currentCategory;
+    private List<CategorySearchDto> child;
+
+    public CategorySearchResponseDto(Category target, List<CategorySearchDto> child) {
+        this.parentIdx = new SimpleCategoryDto(target.getParent());
+        this.currentCategory = new SimpleCategoryDto(target);
+        this.child = child;
+    }
+}
+
+

--- a/problem1/src/main/java/com/board/toy/domain/category/dto/SimpleCategoryDto.java
+++ b/problem1/src/main/java/com/board/toy/domain/category/dto/SimpleCategoryDto.java
@@ -1,0 +1,19 @@
+package com.board.toy.domain.category.dto;
+
+import com.board.toy.domain.category.Category;
+import lombok.Getter;
+
+@Getter
+public class SimpleCategoryDto {
+    private Long id;
+
+    private String name;
+
+    private Boolean del;
+
+    public SimpleCategoryDto(Category category) {
+        this.id = category.getId();
+        this.name = category.getName();
+        this.del = category.getDel();
+    }
+}

--- a/problem1/src/main/java/com/board/toy/domain/category/repository/CategoryRepository.java
+++ b/problem1/src/main/java/com/board/toy/domain/category/repository/CategoryRepository.java
@@ -1,0 +1,11 @@
+package com.board.toy.domain.category.repository;
+
+import com.board.toy.domain.category.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface CategoryRepository extends JpaRepository<Category, Long>, CategoryRepositoryCustom{
+    Optional<Category> findOneByNameContains(String keyword);
+}

--- a/problem1/src/main/java/com/board/toy/domain/category/repository/CategoryRepositoryCustom.java
+++ b/problem1/src/main/java/com/board/toy/domain/category/repository/CategoryRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.board.toy.domain.category.repository;
+
+import com.board.toy.domain.category.dto.CategorySearchDto;
+
+import java.util.List;
+
+public interface CategoryRepositoryCustom {
+    List<CategorySearchDto> findSearchCategories(Long categoryId);
+}

--- a/problem1/src/main/java/com/board/toy/domain/category/repository/CategoryRepositoryImpl.java
+++ b/problem1/src/main/java/com/board/toy/domain/category/repository/CategoryRepositoryImpl.java
@@ -1,0 +1,29 @@
+package com.board.toy.domain.category.repository;
+
+
+
+import com.board.toy.domain.category.dto.CategorySearchDto;
+import com.board.toy.domain.category.dto.QCategorySearchDto;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.board.toy.domain.board.QBoard.board;
+import static com.board.toy.domain.category.QCategory.category;
+import static com.board.toy.domain.categoryboardmapping.QCategoryBoardMapping.categoryBoardMapping;
+
+@RequiredArgsConstructor
+public class CategoryRepositoryImpl implements CategoryRepositoryCustom{
+    private  final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<CategorySearchDto> findSearchCategories(Long categoryId){
+        return queryFactory.select(new QCategorySearchDto(category.id, category.name, category.del, category.parent.id,
+                        categoryBoardMapping.id,
+                        board.id, board.name, board.del, board.anonymous)).from(category)
+                .leftJoin(categoryBoardMapping).on(categoryBoardMapping.categoryId.eq(category.id))
+                .leftJoin(board).on(board.id.eq(categoryBoardMapping.boardId))
+                .where(category.id.eq(categoryId).or(category.parent.id.eq(categoryId))).fetch();
+    }
+}

--- a/problem1/src/main/java/com/board/toy/domain/categoryboardmapping/CategoryBoardMapping.java
+++ b/problem1/src/main/java/com/board/toy/domain/categoryboardmapping/CategoryBoardMapping.java
@@ -1,4 +1,5 @@
-package com.board.toy.domain.board;
+package com.board.toy.domain.categoryboardmapping;
+
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -8,14 +9,11 @@ import lombok.Getter;
 
 @Entity
 @Getter
-public class Board {
+public class CategoryBoardMapping {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    private Long categoryId;
 
-    private String name;
-    private String memo;
-    private Boolean del;
-
-    private Boolean anonymous;
+    private Long boardId;
 }

--- a/problem1/src/main/java/com/board/toy/domain/categoryboardmapping/repository/CategoryBoardMappingRepository.java
+++ b/problem1/src/main/java/com/board/toy/domain/categoryboardmapping/repository/CategoryBoardMappingRepository.java
@@ -1,0 +1,7 @@
+package com.board.toy.domain.categoryboardmapping.repository;
+
+import com.board.toy.domain.categoryboardmapping.CategoryBoardMapping;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryBoardMappingRepository extends JpaRepository<CategoryBoardMapping, Long> {
+}

--- a/problem1/src/main/resources/application.properties
+++ b/problem1/src/main/resources/application.properties
@@ -1,1 +1,6 @@
 spring.application.name=toy
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+server.port=5000
+spring.jpa.hibernate.ddl-auto=none
+spring.jpa.properties.hibernate.show_sql=true


### PR DESCRIPTION
<요구사항>

공지사항은 이름은 같지만 각각 다른 게시판이며
익명 게시판은 모두 같은 게시판이 각각 다른 카테고리에 소속되어 있다.

카테고리들간의 관계 데이터를 parent_idx, child_id 2개의 값으로만 저장 해야 하며 저장된 값을 임의의 자료구조를 통해 구조화 시켜서 위와 같은 관계 데이터를 얻을 수 있어야 한다.

자료구조는 다음과 같은 기능이 필수로 지원 되야 한다.

1. 카테고리 식별자 및 카테고리명으로 검색이 되어야하며, 검색된 결과 값은 해당 카테고리의 하위 카테고리를 모두 담고 있어야 한다.
2. 자료구조는 Json text 로 응답 될 수 있어야 한다. (Json 구조로 변환이 가능해야 한다)

을 충족합니다
